### PR TITLE
Fix AutoYaST schema in SLE 12 SP1

### DIFF
--- a/package/yast2-dhcp-server.changes
+++ b/package/yast2-dhcp-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Nov 17 09:43:38 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix validation of AutoYaST profiles (bsc#954412)
+
+-------------------------------------------------------------------
 Thu Dec  4 09:50:01 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)

--- a/src/autoyast-rnc/dhcp-server.rnc
+++ b/src/autoyast-rnc/dhcp-server.rnc
@@ -15,8 +15,8 @@ dhcp-server = element dhcp-server {
 allowed_interfaces = 
   element allowed_interfaces {
     LIST,
-    allowed_interface+
-}  
+    allowed_interface*
+}
 
 allowed_interface = element allowed_interface { text }
 


### PR DESCRIPTION
Fixes [bsc#954412](https://bugzilla.suse.com/show_bug.cgi?id=954412) for SLE 12 SP1. BTW, `SLE-12-GA` branch is merged into `sle-12-sp1-after_release`.