### PR TITLE
Use ServiceStatus (and other UI improvements/fixes)

### DIFF
--- a/package/yast2-dhcp-server.changes
+++ b/package/yast2-dhcp-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 26 10:36:14 UTC 2015 - ancor@suse.com
+
+- Several UI improvements and fixes, including the usage of the
+  new generic widget to handle the service status.
+- 3.1.6
+
+-------------------------------------------------------------------
 Thu Dec  4 09:50:01 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)

--- a/package/yast2-dhcp-server.spec
+++ b/package/yast2-dhcp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dhcp-server
-Version:        3.1.5
+Version:        3.1.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -25,14 +25,14 @@ Source0:        %{name}-%{version}.tar.bz2
 
 Group:          System/YaST
 License:        GPL-2.0
-BuildRequires:	perl-Digest-SHA1 perl-X500-DN perl-XML-Writer docbook-xsl-stylesheets doxygen libxslt perl-XML-Writer popt-devel sgml-skel update-desktop-files yast2 yast2-perl-bindings yast2-testsuite yast2-dns-server
+BuildRequires:	perl-Digest-SHA1 perl-X500-DN perl-XML-Writer docbook-xsl-stylesheets doxygen libxslt perl-XML-Writer popt-devel sgml-skel update-desktop-files yast2-perl-bindings yast2-testsuite yast2-dns-server
 BuildRequires:  yast2-devtools >= 3.1.10
+# UI::ServiceStatus
+BuildRequires:  yast2 >= 3.1.160
 
 Requires:       perl-gettext yast2-perl-bindings bind-utils perl-X500-DN yast2-ldap perl-Digest-SHA1 perl-Parse-RecDescent
-# Address::CheckMAC && Address::ValidMAC (2.13.73)
-# Punycode
-# Wizard::SetDesktopTitleAndIcon
-Requires:       yast2 >= 2.21.22
+# UI::ServiceStatus
+Requires:       yast2 >= 3.1.160
 # DnsServerAPI::IsServiceConfigurableExternally
 Requires:       yast2-dns-server >= 2.13.16
 

--- a/src/include/dhcp-server/dialogs2.rb
+++ b/src/include/dhcp-server/dialogs2.rb
@@ -80,14 +80,15 @@ module Yast
       @tabs = {
         "start_up"        => {
           "contents"        => VBox(
-            "auto_start_up",
-            #	    `VSpacing(),
-            "use_ldap",
-            VSpacing(),
             "start_stop",
             VSpacing(),
+            "use_ldap",
+            VSpacing(),
             HBox("other_options", HStretch()),
-            VStretch()
+            VStretch(),
+            Right(
+              "apply"
+            )
           ),
           # dialog caption
           "caption"         => _("DHCP Server: Start-Up"),
@@ -96,11 +97,11 @@ module Yast
           # tree item
           "tree_item_label" => _("Start-Up"),
           "widget_names"    => [
-            "auto_start_up",
-            "use_ldap",
             "start_stop",
+            "use_ldap",
             "expert_settings",
-            "other_options"
+            "other_options",
+            "apply"
           ]
         },
         "card_selection"  => {
@@ -211,44 +212,6 @@ module Yast
                   _("When Booting"),
                   # part of help text - radio button label, NO SHORTCUT!!!
                   _("Manually")
-                )
-              }
-            ),
-            "start_stop"      => CWMServiceStart.CreateStartStopWidget(
-              {
-                "service_id"                => "dhcpd",
-                # label - service status
-                "service_running_label"     => _(
-                  "DHCP server is running"
-                ),
-                # label - service status
-                "service_not_running_label" => _(
-                  "DHCP server is not running"
-                ),
-                # push button
-                "start_now_button"          => _(
-                  "&Start DHCP Server Now"
-                ),
-                # push button
-                "stop_now_button"           => _(
-                  "S&top DHCP Server Now"
-                ),
-                "save_now_action"           => fun_ref(
-                  method(:SaveAndRestart),
-                  "void ()"
-                ),
-                # push button
-                "save_now_button"           => _(
-                  "Save Settings and Restart DHCP Server &Now"
-                ),
-                "help"                      => Builtins.sformat(
-                  CWMServiceStart.StartStopHelpTemplate(true),
-                  # part of help text - push button label, NO SHORTCUT!!!
-                  _("Start DHCP Server Now"),
-                  # part of help text - push button label, NO SHORTCUT!!!
-                  _("Stop DHCP Server Now"),
-                  # part of help text - push button label, NO SHORTCUT!!!
-                  _("Save Settings and Restart DHCP Server Now")
                 )
               }
             ),
@@ -2187,15 +2150,6 @@ module Yast
 
     def SetStartService(start)
       DhcpServer.SetStartService(start)
-
-      nil
-    end
-
-    def SaveAndRestart
-      Wizard.CreateDialog
-      Wizard.RestoreHelp(Ops.get(@HELPS, "write", ""))
-      DhcpServer.Write
-      UI.CloseDialog
 
       nil
     end

--- a/src/include/dhcp-server/dialogs2.rb
+++ b/src/include/dhcp-server/dialogs2.rb
@@ -80,7 +80,7 @@ module Yast
       @tabs = {
         "start_up"        => {
           "contents"        => VBox(
-            "start_stop",
+            "service_status",
             VSpacing(),
             "use_ldap",
             VSpacing(),
@@ -97,7 +97,7 @@ module Yast
           # tree item
           "tree_item_label" => _("Start-Up"),
           "widget_names"    => [
-            "start_stop",
+            "service_status",
             "use_ldap",
             "expert_settings",
             "other_options",

--- a/src/include/dhcp-server/helps.rb
+++ b/src/include/dhcp-server/helps.rb
@@ -35,12 +35,6 @@ module Yast
             "This option is only available if the firewall\n" +
             "is enabled.</p>"
         ),
-        # help text 1/5
-        "start"                 => _(
-          "<p><b><big>DHCP Server</big></b></p>\n" +
-            "<p>To run the DHCP server every time your computer is started, set\n" +
-            "<b>Start DHCP Server</b>.</p>"
-        ),
         # help text 2/5
         "chroot"                => _(
           "<p>\n" +
@@ -61,15 +55,15 @@ module Yast
             "To add a new declaration, select a declaration that should include\n" +
             "the new declaration and click <b>Add</b>.\n" +
             "To delete a declaration, select it and click <b>Delete</b>.</p>"
-        ) +
-          # help text 5/5
-          _(
-            "<p><b><big>Advanced Functions</big></b><br>\n" +
-              "Use <b>Advanced</b> to display the log of the DHCP server,\n" +
-              "change network interfaces to which the DHCP server listens,\n" +
-              "or manage TSIG keys that can be used for authentication of \n" +
-              "dynamic DNS updates.</p>"
-          ),
+        ),
+        # help text 5/5
+        "advanced"              => _(
+          "<p><b><big>Advanced Functions</big></b><br>\n" +
+            "Use <b>Advanced</b> to display the log of the DHCP server,\n" +
+            "change network interfaces to which the DHCP server listens,\n" +
+            "or manage TSIG keys that can be used for authentication of \n" +
+            "dynamic DNS updates.</p>"
+        ),
         # help text 1/3, alt. 1
         "subnet"                => _(
           "<p><b><big>Subnet Configuration</big></b><br>\nSet the <b>Network Address</b> and <b>Network Mask</b> of the subnet.</p>"

--- a/src/include/dhcp-server/routines.rb
+++ b/src/include/dhcp-server/routines.rb
@@ -16,13 +16,6 @@ module Yast
       textdomain "dhcp-server"
     end
 
-    # Restart the DHCP daemon
-    def RestartDhcpDaemon
-      Service.RunInitScript("dhcpd", "restart")
-
-      nil
-    end
-
     # Merge section id and key together to one identifier
     # @param [String] type string section type
     # @param [String] id string section identifier

--- a/src/include/dhcp-server/widgets.rb
+++ b/src/include/dhcp-server/widgets.rb
@@ -375,10 +375,11 @@ module Yast
         )
         return nil
       end
-      return :interfaces if event_id == :interfaces
-      return :tsig_keys if event_id == :tsig_keys
-
-      nil
+      if [:interfaces, :tsig_keys].include?(event_id)
+        event_id
+      else
+        nil
+      end
     end
 
     # Handle function of the widget
@@ -1018,8 +1019,8 @@ module Yast
           "store"  => fun_ref(method(:store_service_status), "void (string, map)")
         },
         "apply"           => {
-          "widget" => :custom,
-          "custom_widget" => PushButton(Id("apply"), _("Apply Changes")),
+          "widget" => :push_button,
+          "label"  => _("Apply Changes"),
           "handle" => fun_ref(method(:handle_apply), "symbol (string, map)"),
           "help"   => ""
         },

--- a/src/include/dhcp-server/widgets.rb
+++ b/src/include/dhcp-server/widgets.rb
@@ -190,51 +190,6 @@ module Yast
       confirmAbort
     end
 
-    # Enable or disable a widget according the current status of the service
-    # @param [String] id string widget id
-    # @param [Hash] event map event that caused storing process
-    def dhcpEnabledOrDisabled(id, event)
-      event = deep_copy(event)
-      ev_id = Ops.get(event, "ID")
-      if ev_id == "boot" || ev_id == "never"
-        enabled = UI.QueryWidget(Id("start"), :CurrentButton) != "never"
-        UI.ChangeWidget(Id(id), :Enabled, enabled)
-      end
-
-      nil
-    end
-
-    # Initialize the widget
-    # @param [String] id any widget id
-    def startInit(id)
-      ss = DhcpServer.GetStartService
-      UI.ChangeWidget(Id("start"), :Value, ss)
-
-      nil
-    end
-
-    # Store settings of the widget
-    # @param [String] id string widget id
-    # @param [Hash] event map event that caused storing process
-    def startStore(id, event)
-      event = deep_copy(event)
-      ss = Convert.to_boolean(UI.QueryWidget(Id("start"), :Value))
-      DhcpServer.SetStartService(ss)
-
-      nil
-    end
-
-    # Handle function of the widget
-    # @param [String] id string widget id
-    # @param [Hash] event map event that caused storing process
-    # @return [Symbol] always nil
-    def startHandle(id, event)
-      event = deep_copy(event)
-      start = Convert.to_boolean(UI.QueryWidget(Id("start"), :Value))
-      DhcpServer.SetModified if start != DhcpServer.GetStartService
-      nil
-    end
-
     # chroot widget
 
     # Initialize the widget
@@ -242,7 +197,6 @@ module Yast
     def chrootInit(id)
       ss = DhcpServer.GetChrootJail
       UI.ChangeWidget(Id(id), :Value, ss)
-      chrootHandle(id, { "ID" => "start" })
 
       nil
     end
@@ -264,11 +218,6 @@ module Yast
     # @return [Symbol] always nil
     def chrootHandle(id, event)
       event = deep_copy(event)
-      if Ops.get(event, "ID") == "start"
-        en = Convert.to_boolean(UI.QueryWidget(Id("start"), :Value))
-        UI.ChangeWidget(Id(id), :Enabled, en)
-        return nil
-      end
       start = Convert.to_boolean(UI.QueryWidget(Id(id), :Value))
       DhcpServer.SetModified if start != DhcpServer.GetChrootJail
       nil
@@ -282,12 +231,7 @@ module Yast
       ul = DhcpServer.GetUseLdap
       ldap_available = DhcpServer.GetLdapAvailable
       UI.ChangeWidget(Id(id), :Value, ul)
-
-      if ldap_available
-        ldapHandle(id, { "ID" => "start" })
-      else
-        UI.ChangeWidget(Id(id), :Enabled, ldap_available)
-      end
+      UI.ChangeWidget(Id(id), :Enabled, ldap_available)
 
       nil
     end
@@ -311,11 +255,6 @@ module Yast
     # @return [Symbol] always nil
     def ldapHandle(id, event)
       event = deep_copy(event)
-      if Ops.get(event, "ID") == "start"
-        en = Convert.to_boolean(UI.QueryWidget(Id("start"), :Value))
-        UI.ChangeWidget(Id(id), :Enabled, en)
-        return nil
-      end
       ldap = Convert.to_boolean(UI.QueryWidget(Id(id), :Value))
       if ldap != DhcpServer.GetUseLdap
         SetUseLdap(ldap)
@@ -392,7 +331,7 @@ module Yast
               ),
               Builtins.mergestring(ifaces_not_in_fw, "\n")
             )
-          ) 
+          )
           #return false;
           # FIXME: dialog for adding interfaces into firewall zones
           # only one
@@ -405,7 +344,7 @@ module Yast
               ),
               Ops.get(ifaces_not_in_fw, 0, "")
             )
-          ) 
+          )
           #return false;
           # FIXME: dialog for adding interfaces into firewall zones
         end
@@ -414,16 +353,10 @@ module Yast
       true
     end
 
-
-    # Handle function of the widget
-    # @param [String] id string widget id
-    # @param [Hash] event map event that caused storing process
-    # @return [Symbol] always nil
-    def configTreeHandle(id, event)
-      event = deep_copy(event)
-      if Mode.config &&
-          (Ops.get(event, "ID") == :log || Ops.get(event, "ID") == :interfaces ||
-            Ops.get(event, "ID") == :tsig_keys)
+    # Handle function for the advanced options dropdown
+    def handle_advanced(_id, event)
+      event_id = event["ID"]
+      if Mode.config && [:log, :interfaces, :tsig_keys].include?(event_id)
         # popup message
         Popup.Message(
           _(
@@ -432,54 +365,39 @@ module Yast
         )
         return nil
       end
-      enabled = Convert.to_boolean(UI.QueryWidget(Id("start"), :Value))
-      if Ops.get(event, "ID") == "start"
-        UI.ChangeWidget(Id("configtree"), :Enabled, enabled)
-        UI.ChangeWidget(Id(:adv), :Enabled, enabled)
-        UI.ChangeWidget(Id(:edit), :Enabled, enabled)
-      end
-      if Ops.get(event, "ID") == :log
+      if event_id == :log
         LogView.Display(
           {
             "file"    => "/var/log/messages",
             "grep"    => "dhcpd",
-            "save"    => true,
-            "actions" => [
-              # menubutton entry, try to keep short
-              [
-                _("Restart DHCP Server"),
-                fun_ref(method(:RestartDhcpDaemon), "void ()")
-              ],
-              # menubutton entry, try to keep short
-              [
-                _("Save Settings and Restart DHCP Server"),
-                fun_ref(DhcpServer.method(:Write), "boolean ()")
-              ]
-            ]
+            "save"    => true
           }
         )
         return nil
       end
-      return :interfaces if Ops.get(event, "ID") == :interfaces
-      return :tsig_keys if Ops.get(event, "ID") == :tsig_keys
+      return :interfaces if event_id == :interfaces
+      return :tsig_keys if event_id == :tsig_keys
+
+      nil
+    end
+
+    # Handle function of the widget
+    # @param [String] id string widget id
+    # @param [Hash] event map event that caused storing process
+    # @return [Symbol] always nil
+    def configTreeHandle(id, event)
+      event = deep_copy(event)
       current_item = Convert.to_string(
         UI.QueryWidget(Id("configtree"), :CurrentItem)
       )
-      if current_item == " " || !enabled
-        UI.ChangeWidget(Id(:delete), :Enabled, false) 
-        #	UI::ChangeWidget (`id (`move), `Enabled, false);
-      else
-        UI.ChangeWidget(Id(:delete), :Enabled, true) 
-        #	UI::ChangeWidget (`id (`move), `Enabled, true);
-      end
+      UI.ChangeWidget(Id(:delete), :Enabled, current_item != " ")
       selected = key2typeid(current_item)
       if selected == nil
         Builtins.y2error("Unexistent entry selected")
         return nil
       end
       sel_type = Ops.get(selected, "type", "")
-      if sel_type == "pool" || sel_type == "class" || sel_type == "host" ||
-          !enabled
+      if ["pool", "class", "host"].include?(sel_type)
         UI.ChangeWidget(Id(:add), :Enabled, false)
       else
         UI.ChangeWidget(Id(:add), :Enabled, true)
@@ -527,7 +445,7 @@ module Yast
         )
         configTreeInit(id)
       elsif Ops.get(event, "ID") == :move
-        return nil 
+        return nil
         # TODO move button
       end
       # if (event["ID"]:nil == `add || event["ID"]:nil == `edit)
@@ -555,7 +473,6 @@ module Yast
         )
       )
       UI.ChangeWidget(Id("configtree"), :CurrentItem, " ")
-      configTreeHandle(id, { "ID" => "start" })
       nil
     end
 
@@ -921,26 +838,36 @@ module Yast
       :main
     end
 
+    # Handle function for the 'Apply' button
     def handle_apply(_key, event)
       event_id = event["ID"]
       if event_id == "apply"
-        SaveAndRestart()
+        SaveAndRestart(event)
       end
       nil
     end
 
-    def init_start_stop(_key)
+    def init_service_status(_key)
       # If UI::ServiceStatus is used, do not let DnsServer manage the service
       # status, let the user decide
       DhcpServer.SetWriteOnly(true)
       nil
     end
 
-    def handle_start_stop(_key, event)
+    # Handle function for the ServiceStatus widget
+    def handle_service_status(_key, event)
       event_id = event["ID"]
       if @status_widget.handle_input(event_id) == :enabled_changed
-        DhcpServer.SetStartService(@status_widget.enabled?)
+        DhcpServer.SetModified if @status_widget.enabled? != DhcpServer.GetStartService
       end
+      nil
+    end
+
+    # Store settings of the widget
+    # @param [String] id string widget id
+    # @param [Hash] event map event that caused storing process
+    def store_service_status(_key, _event)
+      DhcpServer.SetStartService(@status_widget.enabled?)
       nil
     end
 
@@ -1082,22 +1009,13 @@ module Yast
           #FIXME CWM should be able to handle virtual widgets
           "widget"        => :textentry
         },
-        "start"                => {
-          "widget" => :checkbox,
-          # check box
-          "label"  => _("&Start DHCP Server"),
-          "help"   => Ops.get(@HELPS, "start", ""),
-          "init"   => fun_ref(method(:startInit), "void (string)"),
-          "handle" => fun_ref(method(:startHandle), "symbol (string, map)"),
-          "store"  => fun_ref(method(:startStore), "void (string, map)"),
-          "opt"    => [:notify]
-        },
-        "start_stop"           => {
+        "service_status"         => {
           "widget" => :custom,
           "custom_widget" => @status_widget.widget,
-          "init"   => fun_ref(method(:init_start_stop), "void (string)"),
-          "handle" => fun_ref(method(:handle_start_stop), "symbol (string, map)"),
-          "help"   => @status_widget.help
+          "help"   => @status_widget.help,
+          "init"   => fun_ref(method(:init_service_status), "void (string)"),
+          "handle" => fun_ref(method(:handle_service_status), "symbol (string, map)"),
+          "store"  => fun_ref(method(:store_service_status), "void (string, map)")
         },
         "apply"           => {
           "widget" => :custom,
@@ -1127,7 +1045,7 @@ module Yast
           "widget"        => :custom,
           "custom_widget" => VWeight(
             1,
-            VBox(
+            HBox(
               VWeight(
                 1,
                 ReplacePoint(
@@ -1140,25 +1058,10 @@ module Yast
                   )
                 )
               ),
-              HBox(
+              VBox(
                 PushButton(Id(:add), Label.AddButton),
                 PushButton(Id(:edit), Label.EditButton),
                 PushButton(Id(:delete), Label.DeleteButton),
-                #			`PushButton (`id (`move), _("&Move")),
-                HStretch(),
-                # menu button
-                MenuButton(
-                  Id(:adv),
-                  _("Ad&vanced"),
-                  [
-                    # item of a menu button
-                    Item(Id(:log), _("Display &Log")),
-                    # item of a menu button
-                    Item(Id(:interfaces), _("&Interface Configuration")),
-                    # item of a menu button
-                    Item(Id(:tsig_keys), _("TSIG Key Management"))
-                  ]
-                )
               )
             )
           ),
@@ -1168,6 +1071,22 @@ module Yast
             method(:configTreeHandle),
             "symbol (string, map)"
           )
+        },
+        "advanced"             => {
+          "widget"        => :custom,
+          "custom_widget" => MenuButton(
+            Id(:adv),
+            _("Ad&vanced"),
+            [
+              # item of a menu button
+              Item(Id(:log), _("Display &Log")),
+              # item of a menu button
+              Item(Id(:interfaces), _("&Interface Configuration")),
+              # item of a menu button
+              Item(Id(:tsig_keys), _("TSIG Key Management"))
+            ]
+          ),
+          "handle"        => fun_ref(method(:handle_advanced), "symbol (string, map)")
         },
         "subnet"               => {
           "widget"        => :custom,

--- a/src/modules/DhcpServer.pm
+++ b/src/modules/DhcpServer.pm
@@ -185,6 +185,12 @@ sub IsDnsServerAvailable () {
     return $dns_server_available;
 }
 
+BEGIN {$TYPEINFO{ServiceName} = [ "function", "string" ];}
+sub ServiceName () {
+    # returns systemd name for the DHCP service
+    return $SERVICE;
+}
+
 sub InitTSIGKeys {
     my $self = shift;
 
@@ -1284,6 +1290,13 @@ sub SetWriteOnly {
     my $self = shift;
 
     $write_only = shift;
+}
+
+BEGIN{$TYPEINFO{GetWriteOnly} = ["function", "boolean"];}
+sub GetWriteOnly {
+    my $self = shift;
+
+    return Boolean ($write_only);
 }
 
 BEGIN{$TYPEINFO{GetAllowedInterfaces} = ["function", ["list", "string"] ];}

--- a/src/modules/DhcpServerUI.rb
+++ b/src/modules/DhcpServerUI.rb
@@ -152,7 +152,6 @@ module Yast
     publish :function => :getOptionsTableWidget, :type => "map <string, any> (list)"
     publish :function => :confirmAbort, :type => "boolean ()"
     publish :function => :confirmAbortIfChanged, :type => "boolean ()"
-    publish :function => :dhcpEnabledOrDisabled, :type => "void (string, map)"
     publish :function => :startInit, :type => "void (string)"
     publish :function => :startStore, :type => "void (string, map)"
     publish :function => :startHandle, :type => "symbol (string, map)"


### PR DESCRIPTION
## What's in the box

One more step into the path to unify handling of services, by using the generic `UI::ServiceStatus` widget from the yast2 package. For background on the topic see the first page of https://docs.google.com/document/d/1TQO-bdqagSOUssGqJsf3eEeMDh2w40BujdOFP9-te0w/edit?usp=sharing

This YaST module currently have three different UIs. A wizard used only during first execution (not changed in this PR), the standard one (this PR fixes one bug and modify it to use the generic widget) and the expert settings interface (reorganized in this PR, in addition to the adoption of the generic widget).

This PR goes together with:

 * https://github.com/yast/yast-yast2/pull/416 Introduces `UI::ServiceStatus` into yast2 in substitution of the temporary `UI:SrvStatusComponent` which had a nasty API. It also provides new methods in `CWM` (the YaST widgets component) to allow saving dialog values without closing the dialog.
 * https://github.com/yast/yast-dns-server/pull/52 Adapts yast2-dns-server to the new widget.

## Standard interface

In addition to the obvious changes, the old interface was not always saving the settings in the "start-up" section when using the "save settings and restart" button. That's fixed in the new UI.

### Old
![old-standard](https://cloud.githubusercontent.com/assets/3638289/11421805/32bd1f70-9437-11e5-8fb0-0f4b9aa79344.png)

### New
![stand-new](https://cloud.githubusercontent.com/assets/3638289/11421803/2d793940-9437-11e5-918b-1d31b56307f6.png)

## Expert settings interfaces

### Old

In this old dialog, the options to save and restart the service were in a dropdown list under "Advanced" -> "Display logs" -> "Advanced"!!!

![old-expert](https://cloud.githubusercontent.com/assets/3638289/11421887/be85f5ae-9437-11e5-9550-5560e19635c6.png)

### New

![new-expert](https://cloud.githubusercontent.com/assets/3638289/11421927/24b41d4c-9438-11e5-89b2-bdc8bb60bbfe.png)
