### PR TITLE
Avoid module to crash when dhcp service is not present

### DIFF
--- a/package/yast2-dhcp-server.changes
+++ b/package/yast2-dhcp-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 23 09:38:55 UTC 2018 - dgonzalez@suse.com
+
+- Avoid module to crash if service is not installed
+  (related to fate#319428).
+- 4.1.1
+
+-------------------------------------------------------------------
 Mon Aug 20 13:47:16 CEST 2018 - schubi@suse.de
 
 - Switched license in spec file from SPDX2 to SPDX3 format.

--- a/package/yast2-dhcp-server.spec
+++ b/package/yast2-dhcp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dhcp-server
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/dhcp-server/dialogs2.rb
+++ b/src/include/dhcp-server/dialogs2.rb
@@ -171,7 +171,7 @@ module Yast
         "inst_summary"    => {
           "contents"     => VBox(
             VSpacing(1),
-            "auto_start_up",
+            "service_widget",
             VSpacing(1),
             "config_summary",
             VSpacing(1),
@@ -181,7 +181,7 @@ module Yast
           # dialog caption
           "wizard"       => _("Start-Up"),
           "widget_names" => [
-            "auto_start_up",
+            "service_widget",
             "config_summary",
             "all_settings_button"
           ]
@@ -192,7 +192,6 @@ module Yast
         Builtins.union(
           @widgets,
           {
-            "auto_start_up"   => service_widget.cwm_definition,
             "use_ldap"        => CWMServiceStart.CreateLdapWidget(
               {
                 "get_use_ldap" => fun_ref(

--- a/src/modules/DhcpServerUI.rb
+++ b/src/modules/DhcpServerUI.rb
@@ -22,9 +22,7 @@ module Yast
       Yast.import "Mode"
       Yast.import "Popup"
       Yast.import "Report"
-      Yast.import "Service"
       Yast.import "SuSEFirewall"
-      Yast.import "SystemdService"
 
       @current_entry_type = ""
       @current_entry_id = ""
@@ -80,13 +78,6 @@ module Yast
       )
 
       nil
-    end
-
-    # Object representing the DHCP service for its usage in the UI code
-    #
-    # @return [Yast::SystemdServiceClass::Service]
-    def service
-      @service ||= SystemdService.find(DhcpServer.ServiceName())
     end
 
     publish :variable => :current_entry_type, :type => "string"


### PR DESCRIPTION
The expected behavior is to ask to user if want to install it first. This was broken when ServiceWidget was introduced and is fixed with this changes.