### PR TITLE
Avoid crash when no service

### DIFF
--- a/package/yast2-dhcp-server.changes
+++ b/package/yast2-dhcp-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 24 14:21:19 UTC 2018 - dgonzalez@suse.com
+
+- Display an information message instead of the service widget
+  when service is not installed (related to fate#319428).
+- 4.1.2
+
+-------------------------------------------------------------------
 Thu Aug 23 09:38:55 UTC 2018 - dgonzalez@suse.com
 
 - Avoid module to crash if service is not installed

--- a/package/yast2-dhcp-server.spec
+++ b/package/yast2-dhcp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dhcp-server
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/dhcp-server/dialogs.rb
+++ b/src/include/dhcp-server/dialogs.rb
@@ -77,7 +77,7 @@ module Yast
       Report.Error(_("Saving the configuration failed")) unless write_settings
       Wizard.CloseDialog
 
-      service_widget.refresh
+      service_widget.refresh if service
 
       nil
     end
@@ -89,7 +89,10 @@ module Yast
     #
     # @return [Boolean] true if settings are saved successfully; false otherwise
     def write_settings
-      DhcpServer.Write && dhcp_service.save(keep_state: Mode.auto)
+      return false unless DhcpServer.Write
+      return true unless service
+
+      service.save(keep_state: Mode.auto)
     end
 
     # Shows a popup asking to user if wants to change settings

--- a/src/include/dhcp-server/widgets.rb
+++ b/src/include/dhcp-server/widgets.rb
@@ -34,15 +34,15 @@ module Yast
     # Returns the service for DHCP
     #
     # @return [Yast2::SystemService] status service
-    def dhcp_service
-      @dhcp_service ||= Yast2::SystemService.find(DhcpServer.ServiceName)
+    def service
+      @service ||= Yast2::SystemService.find(DhcpServer.ServiceName)
     end
 
     # Widget to define status and start mode of the service
     #
     # @return [::CWM::ServiceWidget]
     def service_widget
-      @service_widget ||= ::CWM::ServiceWidget.new(dhcp_service)
+      @service_widget ||= ::CWM::ServiceWidget.new(service)
     end
 
     # Function for deleting entry from section
@@ -1296,7 +1296,28 @@ module Yast
     def InitServiceWidget
       return if @widgets["service_widget"]
 
-      @widgets["service_widget"] = service_widget.cwm_definition
+      @widgets["service_widget"] = service_widget_content
+    end
+
+  private
+
+    # Returns the content to be displayed in the start up section
+    #
+    # Depending on whether the `dhcpd` is installed or not, it will return a
+    #
+    #   * ServiceWidget definition (when installed)
+    #   * Label with an information message (when not)
+    #
+    # @return [Hash]
+    def service_widget_content
+      if service
+        service_widget.cwm_definition
+      else
+        {
+          "widget"        => :custom,
+          "custom_widget" => Left(Label(_("Service dhcpd is not installed")))
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
> This module allows proceeding without install the required packages.
> Therefore, the service widget must not crash because of the service
> absence. Instead, an information message will be displayed.