### PR TITLE
Always use absolute path to binaries (bsc#1118291)

### DIFF
--- a/package/yast2-dhcp-server.changes
+++ b/package/yast2-dhcp-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 12 13:16:55 UTC 2018 - lslezak@suse.cz
+
+- Always use absolute path to binaries (bsc#1118291)
+- Updated testsuite to pass with the new yast2
+- 4.1.5
+
+-------------------------------------------------------------------
 Sun Nov 25 11:56:52 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-dhcp-server.spec
+++ b/package/yast2-dhcp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dhcp-server
-Version:        4.1.4
+Version:        4.1.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/dhcp-server/wizards.rb
+++ b/src/include/dhcp-server/wizards.rb
@@ -10,6 +10,9 @@
 #
 # Representation of the configuration of dhcp-server.
 # Input and output routines.
+
+require "shellwords"
+
 module Yast
   module DhcpServerWizardsInclude
     def initialize_dhcp_server_wizards(include_target)
@@ -177,7 +180,7 @@ module Yast
       if ret == :next
         SCR.Execute(
           path(".target.bash"),
-          Ops.add(Ops.add("touch ", Directory.vardir), "/dhcp_server_done_once")
+          "/usr/bin/touch #{File.join(Directory.vardir, "dhcp_server_done_once").shellescape}"
         )
       end
 

--- a/testsuite/tests/YaPIAddDeclaration.out
+++ b/testsuite/tests/YaPIAddDeclaration.out
@@ -1,7 +1,7 @@
 Dump	==========================================================
 Execute	.target.bash_output "/bin/hostname --short" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Execute	.target.bash_output "/bin/hostname --fqdn" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
-Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
+Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Read	.sysconfig.dhcpd.DHCPD_RUN_CHROOTED "no"
 Read	.sysconfig.dhcpd.DHCPD_INTERFACE "eth0 eth2"
 Read	.sysconfig.dhcpd.DHCPD_OTHER_ARGS "-p 111"

--- a/testsuite/tests/YaPIDeleteDeclartion.out
+++ b/testsuite/tests/YaPIDeleteDeclartion.out
@@ -1,7 +1,7 @@
 Dump	==========================================================
 Execute	.target.bash_output "/bin/hostname --short" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Execute	.target.bash_output "/bin/hostname --fqdn" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
-Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
+Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Read	.sysconfig.dhcpd.DHCPD_RUN_CHROOTED "no"
 Read	.sysconfig.dhcpd.DHCPD_INTERFACE "eth0 eth2"
 Read	.sysconfig.dhcpd.DHCPD_OTHER_ARGS "-p 111"
@@ -18,7 +18,7 @@ Return	true
 Dump	==========================================================
 Execute	.target.bash_output "/bin/hostname --short" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Execute	.target.bash_output "/bin/hostname --fqdn" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
-Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
+Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Read	.sysconfig.dhcpd.DHCPD_RUN_CHROOTED "no"
 Read	.sysconfig.dhcpd.DHCPD_INTERFACE "eth0 eth2"
 Read	.sysconfig.dhcpd.DHCPD_OTHER_ARGS "-p 111"

--- a/testsuite/tests/YaPISetDeclarationDirectives.out
+++ b/testsuite/tests/YaPISetDeclarationDirectives.out
@@ -1,7 +1,7 @@
 Dump	==========================================================
 Execute	.target.bash_output "/bin/hostname --short" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Execute	.target.bash_output "/bin/hostname --fqdn" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
-Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
+Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Read	.sysconfig.dhcpd.DHCPD_RUN_CHROOTED "no"
 Read	.sysconfig.dhcpd.DHCPD_INTERFACE "eth0 eth2"
 Read	.sysconfig.dhcpd.DHCPD_OTHER_ARGS "-p 111"

--- a/testsuite/tests/YaPISetDeclarationOptions.out
+++ b/testsuite/tests/YaPISetDeclarationOptions.out
@@ -1,7 +1,7 @@
 Dump	==========================================================
 Execute	.target.bash_output "/bin/hostname --short" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Execute	.target.bash_output "/bin/hostname --fqdn" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
-Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
+Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Read	.sysconfig.dhcpd.DHCPD_RUN_CHROOTED "no"
 Read	.sysconfig.dhcpd.DHCPD_INTERFACE "eth0 eth2"
 Read	.sysconfig.dhcpd.DHCPD_OTHER_ARGS "-p 111"

--- a/testsuite/tests/YaPISetDeclarationParent.out
+++ b/testsuite/tests/YaPISetDeclarationParent.out
@@ -1,7 +1,7 @@
 Dump	==========================================================
 Execute	.target.bash_output "/bin/hostname --short" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Execute	.target.bash_output "/bin/hostname --fqdn" $["exit":0, "stderr":"localhost", "stdout":"localhost"]
-Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
+Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password show dhcpd.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"localhost", "stdout":"localhost"]
 Read	.sysconfig.dhcpd.DHCPD_RUN_CHROOTED "no"
 Read	.sysconfig.dhcpd.DHCPD_INTERFACE "eth0 eth2"
 Read	.sysconfig.dhcpd.DHCPD_OTHER_ARGS "-p 111"


### PR DESCRIPTION
- Always use absolute path to binaries (bsc#1118291)
- Updated testsuite to pass with the new yast2
- 4.1.5