### PR TITLE
Fixed old testsuite not depending on named service and bind package in test mode.

### DIFF
--- a/package/yast2-dhcp-server.changes
+++ b/package/yast2-dhcp-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul  1 16:18:15 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed failing old testsuite: do not depend on the environment,
+  skip bind absence in Mode.test() (bsc#1138668)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:28:42 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-dhcp-server.spec
+++ b/package/yast2-dhcp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dhcp-server
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Summary:        YaST2 - DHCP Server Configuration
 Group:          System/YaST
@@ -40,8 +40,8 @@ BuildRequires:  yast2-perl-bindings
 BuildRequires:  yast2-testsuite
 BuildRequires:  yast2-dns-server
 BuildRequires:  yast2-devtools >= 4.2.2
-# Yast2::ServiceWidget
-BuildRequires:  yast2 >= 4.1.0
+# Fix old testsuite bind package absence mocks
+BuildRequires:  yast2 >= 4.2.11
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 

--- a/src/modules/DhcpServer.pm
+++ b/src/modules/DhcpServer.pm
@@ -1611,7 +1611,7 @@ configured yet. Create a new configuration?");
 
     Progress->NextStage ();
 
-    $dns_server_available = DnsServerAPI->IsServiceConfigurableExternally();
+    $dns_server_available = (!Mode->test () && DnsServerAPI->IsServiceConfigurableExternally());
     if ($dns_server_available) {
 	DnsServerAPI->Read();
     }
@@ -1656,7 +1656,7 @@ sub Write {
 
     my $ok = 1;
 
-    $modified = $modified || FirewalldWrapper->is_modified ();
+    $modified = $modified || (!Mode->test () && FirewalldWrapper->is_modified ());
 
     if (! $modified)
     {


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1138668

## Problem
- Failing old testsuite in yast2-dhcp-server
- It depends on bind rpm installed.

## Fix

- Do not depend on the package installed at all in Mode.test()
- 4.2.1