### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ config.status
 config.sub
 configure
 configure.ac
+coverage/
 depcomp
+doc/
 install-sh
 missing
 mkinstalldirs
@@ -27,8 +29,10 @@ doc/autodocs/Yast/
 doc/autodocs/css/
 doc/autodocs/js/
 testsuite/*.exp
+testsuite/*.log
+testsuite/raw.tmp.*
 testsuite/tmp.err.*
 testsuite/tmp.out.*
-testsuite/*.log
 testsuite/yast2-dhcp-server.sum
 testsuite/yast2-dhcp-server.test/
+.yardoc/


### PR DESCRIPTION
Just to make [Travis](https://travis-ci.org/yast/yast-dhcp-server/builds/560899550) happy again :)

```bash
rake aborted!
New files missing in git (or add them to to .gitignore):
.yardoc/checksums
.yardoc/object_types
.yardoc/objects/root.dat
.yardoc/proxy_types
coverage/.last_run.json
coverage/.resultset.json
...
```