### PR TITLE
Fix check of 'set' and 'key' options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ dhcp-server.pot
 autom4te.cache
 Makefile.am.common
 *.ami
-doc/autodocs/*.html
+doc/autodocs/
 /testsuite/config/
 /testsuite/run/
 doc/autodocs/.yardoc/
@@ -27,8 +27,10 @@ doc/autodocs/Yast/
 doc/autodocs/css/
 doc/autodocs/js/
 testsuite/*.exp
-testsuite/tmp.err.*
+testsuite/*.err.*
 testsuite/tmp.out.*
 testsuite/*.log
 testsuite/yast2-dhcp-server.sum
 testsuite/yast2-dhcp-server.test/
+.yardoc
+/coverage

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--markup markdown
+--protected
+--readme README.md
+--output-dir ./doc/autodocs
+--files *.md
+src/**/*.rb

--- a/package/yast2-dhcp-server.changes
+++ b/package/yast2-dhcp-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug  6 11:58:58 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix the check of the 'key' and 'value' options when modifying the
+  configuration using the CLI. (bsc#1144351)
+- 3.2.3
+
+-------------------------------------------------------------------
 Wed Jan 18 11:52:24 UTC 2017 - lslezak@suse.cz
 
 - Fixed a crash at start when the "dhcp-server" package was not

--- a/package/yast2-dhcp-server.spec
+++ b/package/yast2-dhcp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dhcp-server
-Version:        3.2.2
+Version:        3.2.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/dhcp-server/commandline.rb
+++ b/src/include/dhcp-server/commandline.rb
@@ -439,8 +439,8 @@ module Yast
         return false
       end
       if Builtins.haskey(options, "set")
-        key = Ops.get_string(options2, "key", "")
-        value = Ops.get_string(options2, "value", "")
+        key = Ops.get_string(options, "key", "")
+        value = Ops.get_string(options, "value", "")
         if key == ""
           # command-line error report
           CommandLine.Print(_("Option key must be set."))


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1144351

## Problem

When the 'set' option is used, the options given are checked in order to determine if the mandatory parameters were given or not. The problem is that the check is checking the wrong options variable.

## Solution

Use the correct options variable.