### PR TITLE
Fixed user-visible messages (bsc#1084015)

### DIFF
--- a/package/yast2-dhcp-server.changes
+++ b/package/yast2-dhcp-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 17 17:18:49 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed user-visible messages (bsc#1084015)
+- 4.2.2
+
+-------------------------------------------------------------------
 Fri Feb  7 08:21:50 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Removed the testsuite

--- a/package/yast2-dhcp-server.spec
+++ b/package/yast2-dhcp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dhcp-server
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - DHCP Server Configuration
 Group:          System/YaST

--- a/src/include/dhcp-server/dialogs2.rb
+++ b/src/include/dhcp-server/dialogs2.rb
@@ -2059,7 +2059,7 @@ module Yast
           UI.SetFocus(Id("other_opts"))
           Popup.Error(
             Builtins.sformat(
-              _("\"-%1\" is not a valid DHCP server commandline option"),
+              _("\"-%1\" is not a valid DHCP server commandline option."),
               k
             )
           )
@@ -2070,7 +2070,7 @@ module Yast
             UI.SetFocus(Id("other_opts"))
             Popup.Error(
               Builtins.sformat(
-                _("DHCP server commandline option \"-%1\" requires an argument"),
+                _("DHCP server commandline option \"-%1\" requires an argument."),
                 k
               )
             )

--- a/src/include/dhcp-server/helps.rb
+++ b/src/include/dhcp-server/helps.rb
@@ -142,9 +142,9 @@ module Yast
         # help text
         "other_options"         => _(
           "<p><b><big>DHCP Server Start-Up Arguments</big></b><br>\n" +
-            "Here you can specify parameters that you want DHCP Server to be started with \n" +
+            "Here you can specify parameters that you want the DHCP Server to be started with \n" +
             "(e.g. \"-p 1234\") for a non-standard port to listen on). For all possible options,\n" +
-            "consult dhcpd manual page. If left blank, default values will be used.</p>"
+            "consult the dhcpd manual page. If left blank, default values will be used.</p>"
         ),
         # Wizard Installation - Step 1 (version for expert UI)
         "card_selection_expert" => _(


### PR DESCRIPTION

## Bugzilla 

https://bugzilla.suse.com/show_bug.cgi?id=1084015


## Description

This puts en_US "translations" which are really fixes for broken English or broken translations back into the sources.


#### en_US.po File

```po
# English message file for YaST2 (@memory@).
# Copyright (C) 2005 SUSE Linux Products GmbH.
# Copyright (C) 2002 SuSE Linux AG.
#
msgid ""
msgstr ""
"Project-Id-Version: YaST (@memory@)\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2018-10-30 16:17+0000\n"
"PO-Revision-Date: 2002-07-18 14:04+0200\n"
"Last-Translator: proofreader <i18n@suse.de>\n"
"Language-Team: English <i18n@suse.de>\n"
"Language: en_US\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=n != 1;"

#. remove leading '-'
#: src/include/dhcp-server/dialogs2.rb:2062
msgid "\"-%1\" is not a valid DHCP server commandline option"
msgstr "\"-%1\" is not a valid DHCP server commandline option."

#: src/include/dhcp-server/dialogs2.rb:2073
msgid "DHCP server commandline option \"-%1\" requires an argument"
msgstr "DHCP server commandline option \"-%1\" requires an argument."

#. help text
#: src/include/dhcp-server/helps.rb:143
msgid ""
"<p><b><big>DHCP Server Start-Up Arguments</big></b><br>\n"
"Here you can specify parameters that you want DHCP Server to be started "
"with \n"
"(e.g. \"-p 1234\") for a non-standard port to listen on). For all possible "
"options,\n"
"consult dhcpd manual page. If left blank, default values will be used.</p>"
msgstr ""
"<p><b><big>DHCP Server Start-Up Arguments</big></b><br>\n"
"Here you can specify parameters that you want the DHCP server to be started "
"with \n"
"(e.g. \"-p 1234\") for a non-standard port to listen on). For all possible "
"options,\n"
"consult the dhcpd manual page. If left blank, default values will be used.</"
"p>"
```
