### PR TITLE
AutoYaST: Added supplements: autoyast(dhcp-server) into the spec file…

### DIFF
--- a/package/yast2-dhcp-server.changes
+++ b/package/yast2-dhcp-server.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Aug 10 17:34:11 CEST 2020 - schubi@suse.de
+
+- AutoYaST: Added supplements: autoyast(dhcp-server) into the spec
+  file in order to install this packages if the section has been
+  defined in the AY configuration file (bsc#1146494).
+- 4.3.1
+
+-------------------------------------------------------------------
 Thu May  7 15:31:15 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-dhcp-server.spec
+++ b/package/yast2-dhcp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dhcp-server
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        YaST2 - DHCP Server Configuration
 Group:          System/YaST
@@ -56,6 +56,8 @@ Requires:       yast2 >= 4.1.22
 # DnsServerAPI::IsServiceConfigurableExternally
 Requires:       yast2-dns-server >= 2.13.16
 Requires:       yast2-ruby-bindings >= 1.0.0
+
+Supplements:    autoyast(dhcp-server)
 
 BuildArch:      noarch
 


### PR DESCRIPTION
… in order to install this packages if the section has been defined in the AY configuration file (bsc#1146494).